### PR TITLE
Better axis inputs and testing

### DIFF
--- a/src/JDFTxFreeNrg/hessian.py
+++ b/src/JDFTxFreeNrg/hessian.py
@@ -64,7 +64,7 @@ def get_projected_K(structure: Structure, K: np.ndarray, molecule_sets: list[dic
     
     Args:
         structure (Structure): pymatgen Structure
-        K (np.ndarray): Hessian matrix
+        K (np.ndarray): Hessian matrix in full form.
         molecule_sets (list[dict] | None): List of molecule sets to project out (or onto).
         reverse (bool): If True, project onto the subspace instead of out of it.
         
@@ -127,7 +127,7 @@ def read_K(calc_dir: Path | str, structure: Structure, expand_to_full: bool = Fa
     Args:
         calc_dir (Path | str): Path to the JDFTx calculation directory
         structure (Structure): pymatgen Structure
-        expand_to_full (bool): Whether to expand the Hessian to include fixed atoms
+        expand_to_full (bool): Whether to expand the Hessian to include fixed atoms (currently expected by all projection functions)
         calc_prefix (str | None): Prefix for the calculation files
     
     Returns:
@@ -188,6 +188,14 @@ def reduce_K(K_full: np.ndarray, structure: Structure) -> np.ndarray:
     return K_small
 
 def get_reduced_structure(structure: Structure) -> Structure:
+    """ Get a reduced structure containing only the free atoms.
+    
+    Args:
+        structure (Structure): pymatgen Structure
+        
+    Returns:
+        Structure: Reduced pymatgen Structure
+    """
     free_idcs = get_free_idcs(structure)
     reduced_structure = Structure.from_sites([site for i, site in enumerate(structure.sites) if i in free_idcs])
     return reduced_structure
@@ -280,8 +288,20 @@ def get_freqs_cm_from_calc_dir(calc_dir: Path, molecule_sets: list[dict] | None 
     return freqs
 
 
-def write_Gaussian_vib_log_from_calc_dir(log_path: Path, calc_dir: Path, molecule_sets: list[dict] | None = None, reverse: bool = False, zero_thresh: float = 1e-3, use_in: bool = True):
-    omegaSqEigs, omegaSqEvecs, evecs = get_omegaSqEigs_evecs_from_calc_dir(calc_dir, molecule_sets=molecule_sets, reverse=reverse)
+def write_Gaussian_vib_log_from_calc_dir(log_path: Path, calc_dir: Path, molecule_sets: list[dict] | None = None, reverse: bool = False, zero_thresh: float = 1e-3, use_in: bool = True) -> None:
+    """ Write a Gaussian-format vibrational log file from a JDFTx calculation directory.
+
+    Helpful for debugging vibrational modes / constructing required projector sets.
+    
+    Args:
+        log_path (Path): Path to write the Gaussian vibrational log file to
+        calc_dir (Path): Path to the JDFTx calculation directory
+        molecule_sets (list[dict] | None): List of molecule sets to project out (or onto).
+        reverse (bool): If True, project onto the subspace instead of out of it.
+        zero_thresh (float): Threshold for identifying zero frequencies in cm^-1
+        use_in (bool): Whether to read the structure from the "in" file (True) or "out" file (False)
+    """
+    omegaSqEigs, omegaSqEvecs, _ = get_omegaSqEigs_evecs_from_calc_dir(calc_dir, molecule_sets=molecule_sets, reverse=reverse)
     if use_in:
         structure = JDFTXInfile.from_file(calc_dir / "in").structure
     else:
@@ -330,6 +350,15 @@ def pert_along_vib_mode(structure: Structure, omegaSqEvecs: np.ndarray, mode_idx
 
 # TODO: Use this function in pre-existing functions that perform this operation
 def get_imaginary_mode_idcs(freqs: list[np.complex128], zero_thresh: 1e-3) -> list[int]:
+    """ Get the indices of the frequencies that are imaginary.
+    
+    Args:
+        freqs (list[np.complex128]): List of frequencies in cm^-1
+        zero_thresh (float): threshold for identifying imaginary frequencies in cm^-1
+
+    Returns:
+        list[int]: List of indices of imaginary frequencies
+    """
     imag_mode_idcs = [i for i, f in enumerate(freqs) if abs(f.imag) >= zero_thresh]
     return imag_mode_idcs
 

--- a/src/JDFTxFreeNrg/projection.py
+++ b/src/JDFTxFreeNrg/projection.py
@@ -144,7 +144,41 @@ def get_translations_molecule(modes: list[Mode], mol_indices: list[int], axes: l
         projectors.append(vec)
     return projectors
 
-def resolve_axis(structure: Structure, axis: str | list[int] | np.ndarray) -> np.ndarray:
+def project_out_vector_from_vector(vector_save: np.ndarray, vector_proj: np.ndarray) -> np.ndarray:
+    overlap = dot(vector_save, vector_proj) / dot(vector_proj, vector_proj)
+    projected_vector = vector_save - overlap * vector_proj
+    return projected_vector / np.linalg.norm(projected_vector)
+
+# TODO: Test this function
+def gen_ortho_axes_R3(axis: np.ndarray) -> list[np.ndarray]:
+    R3 = np.eye(3)
+    axis = axis / np.linalg.norm(axis)
+    overlaps = [abs(np.dot(axis, R3[:, i])) for i in range(3)]
+    idcs = np.argsort(overlaps)
+    i1, i2 = idcs[0], idcs[1]
+    v1 = project_out_vector_from_vector(R3[:, i1], axis)
+    v2 = project_out_vector_from_vector(R3[:, i2], axis)
+    v2 = project_out_vector_from_vector(v2, v1)
+    return [v1, v2]
+
+
+
+
+def resolve_axis(structure: Structure, axis: str | list[int] | np.ndarray | dict) -> list[np.ndarray]:
+    axis_data = axis
+    gen_ortho_set = False
+    if isinstance(axis, dict):
+        gen_ortho_set = axis.get("ortho", False)
+        axis_data = axis.get("axis", None)
+        assert axis_data is not None, "An axis provided as a dictionary must provide axis data (str, list[int], np.ndarray) under the key 'axis'."
+    axis_vec = resolve_axis_no_ortho(structure, axis_data)
+    if gen_ortho_set:
+        ortho_axes = gen_ortho_axes_R3(axis_vec)
+        return ortho_axes
+    else:
+        return [axis_vec]
+
+def resolve_axis_no_ortho(structure: Structure, axis: str | list[int] | np.ndarray) -> np.ndarray:
     if isinstance(axis, np.ndarray):
         return axis
     elif isinstance(axis, str):
@@ -199,7 +233,8 @@ def _resolve_axes(structure: Structure, molecule_sets: list[dict]) -> None:
             else:
                 resolved_axes = []
                 for axis in axes:
-                    resolved_axes.append(resolve_axis(structure, axis))
+                    resolve_axes += resolve_axis(structure, axis)
+                    # resolved_axes.append(resolve_axis(structure, axis))
             mset["axes"] = resolved_axes
 
 

--- a/src/JDFTxFreeNrg/projection.py
+++ b/src/JDFTxFreeNrg/projection.py
@@ -163,30 +163,47 @@ def gen_ortho_axes_R3(axis: np.ndarray) -> list[np.ndarray]:
 
 
 
-
 def resolve_axis(structure: Structure, axis: str | list[int] | np.ndarray | dict) -> list[np.ndarray]:
+    axis_data, gen_ortho_set = _resolve_axis_data(axis)
+    axis_vec = _axis_data_to_vector(structure, axis_data)
+    if gen_ortho_set:
+        return gen_ortho_axes_R3(axis_vec)
+    else:
+        return [axis_vec]
+    
+def _resolve_axis_data(axis: str | list[int] | np.ndarray | dict) -> tuple[np.ndarray, bool]:
     axis_data = axis
     gen_ortho_set = False
     if isinstance(axis, dict):
         gen_ortho_set = axis.get("ortho", False)
-        axis_data = axis.get("axis", None)
-        assert axis_data is not None, "An axis provided as a dictionary must provide axis data (str, list[int], np.ndarray) under the key 'axis'."
-    axis_vec = resolve_axis_no_ortho(structure, axis_data)
-    if gen_ortho_set:
-        ortho_axes = gen_ortho_axes_R3(axis_vec)
-        return ortho_axes
-    else:
-        return [axis_vec]
+        if not "axis" in axis:
+            raise ValueError("An axis provided as a dictionary must provide axis data (str, list[int], np.ndarray) under the key 'axis'.")
+        axis_data = axis["axis"]
+    return axis_data, gen_ortho_set
 
-def resolve_axis_no_ortho(structure: Structure, axis: str | list[int] | np.ndarray) -> np.ndarray:
+def _axis_data_to_vector(structure: Structure, axis: str | list[int] | np.ndarray) -> np.ndarray:
     if isinstance(axis, np.ndarray):
+        if not np.shape(axis) in [(3,), (3,1)]:
+            raise ValueError(
+                f"Axis numpy array must be shape (3,), got shape {np.shape(axis)} "
+                "(if you were trying to provide multiple axes, use a list of arrays instead."
+                "If you were trying to provide indices, use a list of two integers instead.)"
+                )
         return axis
     elif isinstance(axis, str):
+        if not axis in ref_axs:
+            raise ValueError(f"Unknown named axis: {axis}. Valid options are: {list(ref_axs.keys())}")
         return ref_axs[axis]
     elif isinstance(axis, list):
+        if not all([isinstance(i, int) for i in axis]):
+            raise TypeError(f"Axis list must contain integers, got: {axis}")
+        if len(axis) != 2:
+            raise ValueError(f"Axis list must contain exactly two indices, got: {axis}")
         p0 = structure.cart_coords[axis[0]]
         p1 = structure.cart_coords[axis[1]]
         return p1 - p0
+    else:
+        raise TypeError(f"Unexpected axis data type: {type(axis)}")
     
 def resolve_idcss(structure: Structure, molecule_sets: list[dict]) -> None:
     try:
@@ -234,7 +251,6 @@ def _resolve_axes(structure: Structure, molecule_sets: list[dict]) -> None:
                 resolved_axes = []
                 for axis in axes:
                     resolve_axes += resolve_axis(structure, axis)
-                    # resolved_axes.append(resolve_axis(structure, axis))
             mset["axes"] = resolved_axes
 
 

--- a/src/JDFTxFreeNrg/testing.py
+++ b/src/JDFTxFreeNrg/testing.py
@@ -9,6 +9,7 @@ import requests
 import inspect
 from os import remove
 import pickle
+from pymatgen.core import Structure
 
 def anl_spheres_area(rs: list[float], centers: list[np.ndarray]) -> float:
     assert len(rs) == len(centers), "Number of radii must match number of centers."
@@ -593,4 +594,7 @@ def get_freesolv_database(version='0.51'):
 # test_solve_entropy_trans(nsampless=nsampless)
 # test_relative_solve_entropy_trans(nsampless=nsampless)
 
-
+def gen_random_structure(natoms: int, unit_cell_magnitude: float = 10.) -> Structure:
+    coords = np.random.random((natoms, 3))
+    struc = Structure(np.eye(3)*unit_cell_magnitude, list(["H" for _ in range(natoms)]), coords, coords_are_cartesian=True)
+    return struc

--- a/tests/projection.py
+++ b/tests/projection.py
@@ -1,4 +1,6 @@
-from JDFTxFreeNrg.projection import gen_ortho_axes_R3, project_out_vector_from_vector
+from JDFTxFreeNrg.projection import gen_ortho_axes_R3, project_out_vector_from_vector, resolve_axis, ref_axs
+from JDFTxFreeNrg.testing import gen_random_structure
+from typing import Any
 import numpy as np
 import pytest
 
@@ -32,3 +34,101 @@ def test_gen_ortho_axes_R3():
     v2, v3 = gen_ortho_axes_R3(v1)
     _assert_orthogonal_unit_vectors([v2, v3], [v1])
     _assert_orthogonal_unit_vectors([v2], [v3])
+
+
+@pytest.mark.parametrize(
+        ("axis", "natoms"),
+        [
+            ("x", 5),
+            ("y", 10),
+            ("z", 3),
+            ([0, 1], 4),
+            (np.array([1.0, 0.0, 0.0]), 6),
+            ({"axis": "x", "ortho": True}, 7),
+            ({"axis": [2, 3], "ortho": False}, 8),
+        ]
+)
+def test_resolve_axis_data_type(axis: list[int] | str | np.ndarray | dict, natoms: int):
+    structure = gen_random_structure(natoms)
+    axes = resolve_axis(structure, axis)
+    for i, ax in enumerate(axes):
+        assert ax.ndim == 1, f"Resolved axis {i} is not 1D (ndim {ax.ndim})"
+        assert isinstance(ax, np.ndarray), f"Resolved axis {i} is not a numpy array (type {type(ax)})"
+
+
+@pytest.mark.parametrize(
+        ("natoms"),
+        [
+            5,
+            10,
+            3,
+        ]
+)
+def test_resolve_axis_named_axes(natoms: int):
+    structure = gen_random_structure(natoms)
+    for axis_name in ref_axs.keys():
+        axis = ref_axs[axis_name]
+        axis_out = resolve_axis(structure, axis_name)
+        assert len(axis_out) == 1, f"Expected single axis output for named axis {axis_name}, got {len(axis_out)}"
+        ax = axis_out[0]
+        assert np.allclose(ax, axis), f"Resolved axis for named axis {axis_name} does not match reference axis."
+
+
+@pytest.mark.parametrize(
+        ("natoms"),
+        [
+            5,
+            10,
+            3,
+        ]
+)
+def test_resolve_axis_pair_indices(natoms: int):
+    structure = gen_random_structure(natoms)
+    for i1 in range(natoms):
+        for _i2 in range(natoms-1):
+            i2 = (_i2 + i1 + 1) % natoms
+            axis_indices = [i1, i2]
+            p0 = structure.cart_coords[axis_indices[0]]
+            p1 = structure.cart_coords[axis_indices[1]]
+            expected_axis = p1 - p0
+            axis_out = resolve_axis(structure, axis_indices)
+            assert len(axis_out) == 1, f"Expected single axis output for axis indices {axis_indices}, got {len(axis_out)}"
+            ax = axis_out[0]
+            assert np.allclose(ax, expected_axis), f"Resolved axis for indices {axis_indices} does not match expected axis."
+
+@pytest.mark.parametrize(
+        ("axis", "natoms"),
+        [
+            ("x", 5),
+            ("y", 10),
+            ("z", 3),
+            ([0, 1], 4),
+            (np.array([1.0, 0.0, 0.0]), 6),
+        ]
+)
+def test_resolve_axis_generate_ortho_set(axis: list[int] | str | np.ndarray | dict, natoms: int):
+    structure = gen_random_structure(natoms)
+    reg_axis = resolve_axis(structure, axis)[0]
+    orthog_axes = resolve_axis(structure, {"axis": axis, "ortho": True})
+    assert len(orthog_axes) == 2, f"Expected 2 orthogonal axes generated from axis {axis}, got {len(orthog_axes)}"
+    _assert_orthogonal_unit_vectors(orthog_axes, [reg_axis])
+    redundant_axes = resolve_axis(structure, {"axis": axis, "ortho": False})
+    assert len(redundant_axes) == 1, f"Expected 1 axis generated from axis {axis} with ortho=False, got {len(redundant_axes)}"
+    assert np.allclose(redundant_axes[0], reg_axis), f"Axis generated from axis {axis} with ortho=False does not match regular resolved axis."
+
+
+@pytest.mark.parametrize(
+        ("axis", "exception"),
+        [
+            ({"ortho": True}, ValueError),
+            (np.ones(5), ValueError),
+            ("invalid_axis_name", ValueError),
+            ({"axis": 5, "ortho": True}, TypeError),
+            (["a", "b"], TypeError),
+            (["x", 1], TypeError),
+        ]
+)
+def test_resolve_axis_invalid_inputs(axis: Any, exception: Exception):
+    structure = gen_random_structure(5)
+    with pytest.raises(exception):
+        resolve_axis(structure, axis)

--- a/tests/projection.py
+++ b/tests/projection.py
@@ -1,0 +1,34 @@
+from JDFTxFreeNrg.projection import gen_ortho_axes_R3, project_out_vector_from_vector
+import numpy as np
+import pytest
+
+
+def _assert_orthogonal_unit_vectors(vtests: list[np.ndarray], vrefs: list[np.ndarray], atol: float = 1e-6):
+    for i_test, vtest in enumerate(vtests):
+        assert vtest.ndim == 1, f"Test vector {i_test} is not 1D (ndim {vtest.ndim})"
+        assert np.isclose(np.linalg.norm(vtest), 1.0, atol=atol), f"Test vector {i_test} is not unit length (norm {np.linalg.norm(vtest)})"
+        for i_ref, vref in enumerate(vrefs):
+            dotprod = np.dot(vtest, vref)
+            assert np.isclose(dotprod, 0.0, atol=atol), f"Test vector {i_test} is not orthogonal to reference vector {i_ref} (dot product {dotprod})"
+
+
+@pytest.mark.parametrize(
+        ("d"),
+        [2, 3, 5, 10
+        ]
+)
+def test_project_out_vector_from_vector(d: int):
+    v1 = np.random.random((d,))
+    v2 = np.random.random((d,))
+    v2_proj = project_out_vector_from_vector(v2, v1)
+    _assert_orthogonal_unit_vectors([v2_proj], [v1])
+    assert np.isclose(np.dot(v2_proj, v1), 0.0), f"Projection failed to be orthogonal in dimension {d} (dot product {np.dot(v2_proj, v1)})"
+    assert v2_proj.shape == (d,), f"Projected vector has incorrect shape in dimension {d}"
+    assert np.isclose(1.0, np.linalg.norm(v2_proj)), f"Projected vector is not normalized in dimension {d}"
+
+
+def test_gen_ortho_axes_R3():
+    v1 = np.random.random((3,))
+    v2, v3 = gen_ortho_axes_R3(v1)
+    _assert_orthogonal_unit_vectors([v2, v3], [v1])
+    _assert_orthogonal_unit_vectors([v2], [v3])

--- a/tests/vib.py
+++ b/tests/vib.py
@@ -95,6 +95,13 @@ def test_pert_along_im_freqs_helper(natoms: int, zero_thresh: float):
         _pert_along_im_freqs_helper(struc, K_proj, disps=[0.1]*(len(im_eig_idcs)+2), zero_thresh=zero_thresh)
 
 
+@pytest.mark.parametrize(
+        ("natoms", "zero_thresh"),
+        [
+            (5, 1e-3),
+            (8, 1e-4),
+        ]
+)
 def test_pert_along_im_freqs(natoms: int, zero_thresh: float):
     # TODO: Hard-code in a Hessian with known imaginary modes to test the functionality
     struc = gen_random_structure(natoms)

--- a/tests/vib.py
+++ b/tests/vib.py
@@ -1,14 +1,11 @@
 import pytest
 from JDFTxFreeNrg.qrrho import get_qrrho_vib_entropies, get_qrrho_vib_enthalpies
 from JDFTxFreeNrg.standard import get_enthalpy_vib, get_entropy_vib, k_ev
+from JDFTxFreeNrg.testing import gen_random_structure
 from JDFTxFreeNrg.hessian import pert_along_vec, pert_along_vib_mode, get_imaginary_mode_idcs, _pert_along_im_freqs_helper, solve_vib_modes, get_freqs, pert_along_im_freqs
 import numpy as np
 from pymatgen.core import Structure
 
-def gen_random_structure(natoms: int, unit_cell_magnitude: float = 10.) -> Structure:
-    coords = np.random.random((natoms, 3))
-    struc = Structure(np.eye(3)*unit_cell_magnitude, list(["H" for _ in range(natoms)]), coords, coords_are_cartesian=True)
-    return struc
 
 @pytest.mark.parametrize(
         ("natoms", "disp"),


### PR DESCRIPTION
- the value under key "axis" in a molecule_set can now (also) be a dictionary, allowing for specifying `"ortho": True` which will add the two axes in R3 orthogonal to the axis (specified in the dictionary `"axis": ... (np.ndarray | list[int] | str)`) into the raw projector (as per #21 )
- `resolve_axis` function now has much better error catching
- Testing for new axis resolution functionality